### PR TITLE
show all columns on wide screens

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,7 +63,7 @@ ReactDOM.render(
   <React.StrictMode>
     <section className="hero">
       <div className="hero-body">
-        <div className="container is-max-desktop">
+        <div className="container">
           <div className="columns is-centered">
             <div className="column has-text-centered">
               <h1 className="title is-1 publication-title">
@@ -122,7 +122,7 @@ ReactDOM.render(
 
 
               <section className="section">
-                <div className="container is-max-desktop">
+                <div className="container">
                   <div className="columns is-centered has-text-centered">
                     <div className="column is-four-fifths">
                       <h2 className="title is-3">Submitting Custom Models</h2>


### PR DESCRIPTION
achieved by removing the `is-max-desktop` tag on the `container` div.

this allows Bulma CSS to dynamically select width based on its [container logic](https://bulma.io/documentation/layout/container/).

before
![image](https://github.com/user-attachments/assets/0c68a275-eb74-42d8-b880-0e69ff46a193)

after
![image](https://github.com/user-attachments/assets/a2df305c-3ca3-4f75-9c96-ef3dd583d4d9)